### PR TITLE
Fix Electric Locomotives having fuel slots

### DIFF
--- a/Localized_Charging_1.1.0/prototypes/vehicles.lua
+++ b/Localized_Charging_1.1.0/prototypes/vehicles.lua
@@ -22,10 +22,7 @@ data:extend({
 		order="electric-locomotive",
 		equipment_grid = "voltage-electric-locomotive",
 		equipment_categories = {"armor"},
-		energy_source =
-		{
-			type = "burner",
-			effectivity = 1,
+		burner = {
 			fuel_inventory_size = 0,
 		},
 		front_light = {


### PR DESCRIPTION
In 0.15 electric locomotives have slots for solid fuel, although they shouldn't have any.